### PR TITLE
Custom Target Form - Automatic Bone Selection and Orientation

### DIFF
--- a/json-specs/input-spec.json
+++ b/json-specs/input-spec.json
@@ -406,5 +406,11 @@
         "default": 1,
         "type": "int",
         "doc": "export every skip_frame-th frames for time dependent simulations"
+    },
+    {
+        "pointer": "/curve_center_target_automatic_bone_generation",
+        "type": "bool",
+        "default": false,
+        "doc": "Set this value to true if the bone used by curve center target is automatically generated if more than 1 bone intersects with the plane fit to the curve loops (hem, collar, cuff, etc.)"
     }
 ]

--- a/src/polyfem/main.cpp
+++ b/src/polyfem/main.cpp
@@ -258,7 +258,7 @@ int main(int argc, char **argv)
 		}
 
 		const auto tmp_curves = boundary_curves(gstate.garment.f);
-		auto center_target_form = std::make_shared<CurveTargetForm>(initial_garment_v, tmp_curves, gstate.skeleton_v, gstate.target_skeleton_v, gstate.skeleton_b, in_args["is_skirt"]);
+		auto center_target_form = std::make_shared<CurveTargetForm>(initial_garment_v, tmp_curves, gstate.skeleton_v, gstate.target_skeleton_v, gstate.skeleton_b, in_args["is_skirt"], in_args["curve_center_target_automatic_bone_generation"]);
 		center_target_form->set_weight(in_args["curve_center_target_weight"]);
 		persistent_full_forms.push_back(center_target_form);
 	}

--- a/src/polyfem/solver/forms/garment_forms/CurveCenterTargetForm.cpp
+++ b/src/polyfem/solver/forms/garment_forms/CurveCenterTargetForm.cpp
@@ -61,6 +61,10 @@ namespace polyfem::solver
             return eigensolver.eigenvectors().col(0);
         }
 
+        // Nvidia actively chooses to use the MIT license for this section of code.
+        // SPDX-License-Identifier: MIT
+        // #########################################################
+
 		template <class T>
 		Eigen::Matrix<T, -1, 3> project_points_to_plane(
 			const Eigen::Matrix<T, -1, 3> &points,
@@ -322,6 +326,7 @@ namespace polyfem::solver
 			skeleton_edges.row(new_edge_idx) << 0, start_idx; // Root vertex index is 0
 			skeleton_edges.row(new_edge_idx + 1) << start_idx, end_idx;
 		}
+        // #########################################################
 	}
 
     CurveCenterTargetForm::CurveCenterTargetForm(
@@ -533,6 +538,9 @@ namespace polyfem::solver
             const Eigen::Vector3d center = V(curves_[j], Eigen::all).colwise().sum() / curves_[j].size();
             const Eigen::Vector3d curve_normal = fit_plane(V(curves_[j], Eigen::all)).normalized();
 
+            // Nvidia actively chooses to use the MIT license for this section of code.
+            // SPDX-License-Identifier: MIT
+            // #########################################################
             auto bone_intersection_points = count_bone_intersections<double>(V(curves_[j], Eigen::all), source_skeleton_v_, skeleton_edges_);
             if (bone_intersection_points.size() > 0)
             {
@@ -557,7 +565,7 @@ namespace polyfem::solver
 
                 add_bone_to_both_skeletons_with_root_as_parent(start_point, end_point, source_skeleton_v_, target_skeleton_v_, skeleton_edges_);
             }
-
+            // #########################################################
 
             logger().debug("curve normal {}", curve_normal.transpose());
 

--- a/src/polyfem/solver/forms/garment_forms/CurveCenterTargetForm.cpp
+++ b/src/polyfem/solver/forms/garment_forms/CurveCenterTargetForm.cpp
@@ -8,6 +8,7 @@
 
 #include <polyfem/mesh/MeshUtils.hpp>
 #include <igl/write_triangle_mesh.h>
+#include <optional>
 
 namespace polyfem::solver
 {
@@ -59,7 +60,269 @@ namespace polyfem::solver
 
             return eigensolver.eigenvectors().col(0);
         }
-    }
+
+		template <class T>
+		Eigen::Matrix<T, -1, 3> project_points_to_plane(
+			const Eigen::Matrix<T, -1, 3> &points,
+			const Eigen::Vector<T, 3> &plane_normal,
+			const Eigen::Vector<T, 3> &plane_point)
+		{
+			return points - (points * plane_normal).asDiagonal() * plane_normal.transpose().replicate(points.rows(), 1);
+		}
+
+		template <class T>
+		Eigen::VectorXi graham_scan(const Eigen::Matrix<T, -1, 2> &points)
+		{
+			const int n = points.rows();
+			if (n <= 2)
+			{
+				return Eigen::VectorXi::LinSpaced(n, 0, n - 1);
+			}
+
+			// Find point with lowest y-coordinate (and leftmost if tied)
+			int lowest = 0;
+			for (int i = 1; i < n; i++)
+			{
+				if (points(i, 1) < points(lowest, 1) || (points(i, 1) == points(lowest, 1) && points(i, 0) < points(lowest, 0)))
+				{
+					lowest = i;
+				}
+			}
+
+			// Sort points by polar angle with lowest point
+			std::vector<int> indices(n);
+			std::iota(indices.begin(), indices.end(), 0);
+			std::swap(indices[0], indices[lowest]);
+
+			std::sort(indices.begin() + 1, indices.end(),
+					  [&](int i, int j) {
+						  const T angle_i = std::atan2(points(i, 1) - points(lowest, 1),
+													   points(i, 0) - points(lowest, 0));
+						  const T angle_j = std::atan2(points(j, 1) - points(lowest, 1),
+													   points(j, 0) - points(lowest, 0));
+						  if (std::abs(angle_i - angle_j) < 1e-10)
+						  {
+							  // If angles are equal, sort by distance
+							  const T dist_i = (points.row(i) - points.row(lowest)).squaredNorm();
+							  const T dist_j = (points.row(j) - points.row(lowest)).squaredNorm();
+							  return dist_i < dist_j;
+						  }
+						  return angle_i < angle_j;
+					  });
+
+			// Remove collinear points
+			std::vector<int> unique_indices;
+			unique_indices.push_back(indices[0]);
+			for (int i = 1; i < n; i++)
+			{
+				while (unique_indices.size() >= 2)
+				{
+					const int p1 = unique_indices[unique_indices.size() - 2];
+					const int p2 = unique_indices[unique_indices.size() - 1];
+					const int p3 = indices[i];
+
+					const T cross = (points(p2, 0) - points(p1, 0)) * (points(p3, 1) - points(p1, 1)) - (points(p2, 1) - points(p1, 1)) * (points(p3, 0) - points(p1, 0));
+
+					if (cross > 1e-10)
+					{
+						break;
+					}
+					unique_indices.pop_back();
+				}
+				unique_indices.push_back(indices[i]);
+			}
+
+			// Convert to Eigen vector
+			Eigen::VectorXi hull(unique_indices.size());
+			for (int i = 0; i < unique_indices.size(); i++)
+			{
+				hull(i) = unique_indices[i];
+			}
+
+			return hull;
+		}
+
+		template <class T>
+		Eigen::Matrix<T, -1, 2> compute_curve_convex_hull_2d(
+			const Eigen::Matrix<T, -1, 3> &points)
+		{
+			// Fit plane to points
+			const Eigen::Vector3d plane_normal = fit_plane(points);
+
+			// Project points onto plane
+			const Eigen::Vector3d plane_point = points.colwise().mean();
+			const Eigen::Matrix<T, -1, 3> projected_points = project_points_to_plane(points, plane_normal, plane_point);
+
+			// Find orthonormal basis for plane
+			Eigen::Vector3d u = plane_normal.cross(Eigen::Vector3d::UnitX());
+			if (u.norm() < 1e-10)
+			{
+				u = plane_normal.cross(Eigen::Vector3d::UnitY());
+			}
+			u.normalize();
+			const Eigen::Vector3d v = plane_normal.cross(u);
+
+			// Project points onto 2D basis
+			Eigen::Matrix<T, -1, 2> points_2d(points.rows(), 2);
+			for (int i = 0; i < points.rows(); i++)
+			{
+				points_2d(i, 0) = projected_points.row(i).dot(u);
+				points_2d(i, 1) = projected_points.row(i).dot(v);
+			}
+
+			// Compute convex hull in 2D
+			Eigen::VectorXi hull;
+			hull = graham_scan(points_2d);
+
+			// Return hull vertices in 2D
+			return points_2d(hull, Eigen::all);
+		}
+
+		template <class T>
+		bool is_point_in_convex_hull_2d(
+			const Eigen::Vector<T, 3> &point,
+			const Eigen::Vector<T, 3> &plane_normal,
+			const Eigen::Vector<T, 3> &plane_point,
+			const Eigen::Matrix<T, -1, 2> &hull_2d)
+		{
+			// Project point onto plane
+			const Eigen::Vector<T, 3> projected_point = point - (point - plane_point).dot(plane_normal) * plane_normal;
+
+			// Find orthonormal basis for plane
+			Eigen::Vector3d u = plane_normal.cross(Eigen::Vector3d::UnitX());
+			if (u.norm() < 1e-10)
+			{
+				u = plane_normal.cross(Eigen::Vector3d::UnitY());
+			}
+			u.normalize();
+			const Eigen::Vector3d v = plane_normal.cross(u);
+
+			// Project point onto 2D basis
+			const T point_2d_x = projected_point.dot(u);
+			const T point_2d_y = projected_point.dot(v);
+
+			// Check if point is inside convex hull using winding number algorithm
+			int winding_number = 0;
+			for (int i = 0; i < hull_2d.rows(); i++)
+			{
+				const int j = (i + 1) % hull_2d.rows();
+				const T x1 = hull_2d(i, 0) - point_2d_x;
+				const T y1 = hull_2d(i, 1) - point_2d_y;
+				const T x2 = hull_2d(j, 0) - point_2d_x;
+				const T y2 = hull_2d(j, 1) - point_2d_y;
+
+				if (y1 <= 0 && y2 > 0)
+				{
+					if (x1 * y2 - x2 * y1 > 0)
+					{
+						winding_number++;
+					}
+				}
+				else if (y1 > 0 && y2 <= 0)
+				{
+					if (x1 * y2 - x2 * y1 < 0)
+					{
+						winding_number--;
+					}
+				}
+			}
+
+			return winding_number != 0;
+		}
+
+		template <class T>
+		std::optional<Eigen::Vector<T, 3>> bone_plane_intersection(
+			const Eigen::Vector<T, 3> &bone_start,
+			const Eigen::Vector<T, 3> &bone_end,
+			const Eigen::Vector<T, 3> &plane_normal,
+			const Eigen::Vector<T, 3> &plane_point)
+		{
+			// Compute bone direction vector
+			const Eigen::Vector<T, 3> bone_dir = bone_end - bone_start;
+
+			// Compute denominator for intersection calculation
+			const T denom = bone_dir.dot(plane_normal);
+
+			// Check if bone is parallel to plane
+			if (std::abs(denom) < 1e-10)
+			{
+				return std::nullopt;
+			}
+
+			// Compute intersection parameter
+			const T t = (plane_point - bone_start).dot(plane_normal) / denom;
+
+			// Check if intersection is within bone segment
+			if (t < 0 || t > 1)
+			{
+				return std::nullopt;
+			}
+
+			// Return intersection point
+			return bone_start + t * bone_dir;
+		}
+
+		template <class T>
+		std::vector<Eigen::Vector3<T>> count_bone_intersections(
+			const Eigen::Matrix<T, Eigen::Dynamic, 3> &curve_points,
+			const Eigen::Matrix<T, Eigen::Dynamic, 3> &skeleton_v,
+			const Eigen::MatrixXi &skeleton_edges)
+		{
+			// Fit plane to curve points
+			const Eigen::Vector3<T> plane_normal = fit_plane(curve_points).normalized();
+			const Eigen::Vector3<T> plane_point = curve_points.colwise().mean();
+
+			const Eigen::Matrix<T, Eigen::Dynamic, 2> hull_2d = compute_curve_convex_hull_2d<T>(curve_points);
+
+			// Store intersecting bone indices
+			std::vector<Eigen::Vector3<T>> intersection_points;
+			for (int i = 0; i < skeleton_edges.rows(); i++)
+			{
+				const Eigen::Vector3<T> bone_start = skeleton_v.row(skeleton_edges(i, 0));
+				const Eigen::Vector3<T> bone_end = skeleton_v.row(skeleton_edges(i, 1));
+
+				// Find intersection point with plane
+				auto intersection = bone_plane_intersection(bone_start, bone_end, plane_normal, plane_point);
+				if (!intersection)
+				{
+					continue;
+				}
+				// Check if intersection point is inside convex hull
+				if (is_point_in_convex_hull_2d<T>(*intersection, plane_normal, plane_point, hull_2d))
+				{
+					intersection_points.push_back(*intersection);
+				}
+			}
+
+			return intersection_points;
+		}
+
+		void add_bone_to_both_skeletons_with_root_as_parent(
+			const Eigen::Vector3d &start_point,
+			const Eigen::Vector3d &end_point,
+			Eigen::MatrixXd &source_skeleton_v,
+			Eigen::MatrixXd &target_skeleton_v,
+			Eigen::MatrixXi &skeleton_edges)
+		{
+			// Add new vertices to skeleton
+			const int start_idx = source_skeleton_v.rows();
+			const int end_idx = start_idx + 1;
+
+			source_skeleton_v.conservativeResize(end_idx + 1, 3);
+			source_skeleton_v.row(start_idx) = start_point;
+			source_skeleton_v.row(end_idx) = end_point;
+
+			target_skeleton_v.conservativeResize(end_idx + 1, 3);
+			target_skeleton_v.row(start_idx) = start_point;
+			target_skeleton_v.row(end_idx) = end_point;
+
+			// Add new edge to skeleton
+			const int new_edge_idx = skeleton_edges.rows();
+			skeleton_edges.conservativeResize(new_edge_idx + 2, 2);
+			skeleton_edges.row(new_edge_idx) << 0, start_idx; // Root vertex index is 0
+			skeleton_edges.row(new_edge_idx + 1) << start_idx, end_idx;
+		}
+	}
 
     CurveCenterTargetForm::CurveCenterTargetForm(
         const Eigen::MatrixXd &V, 
@@ -266,9 +529,36 @@ namespace polyfem::solver
 
         for (int j = 0; j < curves_.size(); j++)
         {
-            const Eigen::Vector3d center = V(curves_[j], Eigen::all).colwise().sum() / curves_[j].size();
 
+            const Eigen::Vector3d center = V(curves_[j], Eigen::all).colwise().sum() / curves_[j].size();
             const Eigen::Vector3d curve_normal = fit_plane(V(curves_[j], Eigen::all)).normalized();
+
+            auto bone_intersection_points = count_bone_intersections<double>(V(curves_[j], Eigen::all), source_skeleton_v_, skeleton_edges_);
+            if (bone_intersection_points.size() > 0)
+            {
+                logger().debug("curve {} has {} bone intersections", j, bone_intersection_points.size());
+            } 
+
+            if (bone_intersection_points.size() > 1)
+            {
+                // If we have intersection points, create new bone as the average of the others.
+                
+                // Calculate average intersection point
+                Eigen::Vector3d avg_intersection = Eigen::Vector3d::Zero();
+                for (const auto& point : bone_intersection_points) {
+                    avg_intersection += point;
+                }
+                avg_intersection /= bone_intersection_points.size();
+
+                // Create two vertices per bone
+                const double bone_length = 0.1; // Small fixed length
+                const Eigen::Vector3d start_point = avg_intersection - 0.5 * bone_length * curve_normal;
+                const Eigen::Vector3d end_point = avg_intersection + 0.5 * bone_length * curve_normal;
+
+                add_bone_to_both_skeletons_with_root_as_parent(start_point, end_point, source_skeleton_v_, target_skeleton_v_, skeleton_edges_);
+            }
+
+
             logger().debug("curve normal {}", curve_normal.transpose());
 
             // Project centers to original skeleton bones

--- a/src/polyfem/solver/forms/garment_forms/CurveCenterTargetForm.hpp
+++ b/src/polyfem/solver/forms/garment_forms/CurveCenterTargetForm.hpp
@@ -61,7 +61,8 @@ namespace polyfem::solver
 			const Eigen::MatrixXd &source_skeleton_v,
 			const Eigen::MatrixXd &target_skeleton_v,
 			const Eigen::MatrixXi &skeleton_edges,
-			const bool is_skirt = false);
+			const bool is_skirt = false,
+			const bool automatic_bone_generation = false);
 		virtual ~CurveTargetForm() = default;
 
 		std::string name() const override { return "curve-target"; }
@@ -92,5 +93,7 @@ namespace polyfem::solver
 
 		Eigen::VectorXi bones;
 		std::vector<Eigen::VectorXd> relative_positions;
+
+		const bool automatic_bone_generation_;
 	};
 }


### PR DESCRIPTION
What's the issue? 
To identify a bone to anchor a boundary curve (hem/cuff), the center of the boundary curve is compared to all the bones. The closest bone is chosen, and the direction of that bone determines the target normal for the boundary.

This MR instead averages all the positions of bones that are inside the boundary curve, then orients the curve based on that average bone position and the plane curve normal (rather than using the bone directions.

Here is the steps: 
1. For each curve, fit a plane to it.
2. Project the curve points to the fit plane.
3. Compute the convex hull of the curve points in the 2D plane.
4. Identify the number of bones that intersect with the interior of this convex hull region.
5. If that number of bones is greater than 1, identify all the intersection points of each intersecting bones, then average them together to find the average bone intersection point.
6. Create a small virtual bone at this location, oriented along the plane normal. 
7. Use these new virtual bones when assigning the bone for CurveTargetForm.

In my test example, here's a before and after:
<img width="891" height="713" alt="image" src="https://github.com/user-attachments/assets/2805c176-6759-49a5-89c4-222d65516ce8" />

Let me know if you have any questions!